### PR TITLE
add ability to ignore null properties

### DIFF
--- a/src/RestSharp.SnakeCaseSerializer.Tests/SnakeCaseSerializationStrategyTests.cs
+++ b/src/RestSharp.SnakeCaseSerializer.Tests/SnakeCaseSerializationStrategyTests.cs
@@ -7,11 +7,22 @@ namespace RestSharp.SnakeCaseSerializer.Tests
     [TestFixture]
     public class SnakeCaseSerializationStrategyTests
     {
-        public SnakeCaseSerializationStrategyTests()
+        private SnakeCaseSerializationStrategy strategyUnderTest;
+
+        [SetUp]
+        public void SetUp()
         {
-            SimpleJson.CurrentJsonSerializerStrategy= new SnakeCaseSerializationStrategy();
+            this.strategyUnderTest = new SnakeCaseSerializationStrategy();
+            SimpleJson.CurrentJsonSerializerStrategy = this.strategyUnderTest;
         }
-       
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.strategyUnderTest = null;
+            SimpleJson.CurrentJsonSerializerStrategy = null;
+        }
+
         [Test]
         public void Should_SerializeProperties_As_SnakeCase()
         {
@@ -37,6 +48,43 @@ namespace RestSharp.SnakeCaseSerializer.Tests
             const string expected = "{\"number_1_property\":\"test\"}";
 
             Assert.AreEqual(expected, json);
+        }
+
+        [Test]
+        public void WhenIgnoringNullValues_Should_Not_Serialize_Null_Properties()
+        {
+            this.strategyUnderTest.IgnoreNullProperties = true;
+
+            var json = SimpleJson.SerializeObject(new TestData
+            {
+                SomeProperty = "test",
+                SomeOtherProperty = null
+            });
+            const string expected = "{\"some_property\":\"test\"}";
+
+            Assert.AreEqual(expected, json);
+        }
+
+        [Test]
+        public void WhenNotIgnoringNullValues_Should_Serialize_Null_Properties()
+        {
+            this.strategyUnderTest.IgnoreNullProperties = false;
+
+            var json = SimpleJson.SerializeObject(new TestData
+            {
+                SomeProperty = "test",
+                SomeOtherProperty = null
+            });
+            const string expected = "{\"some_property\":\"test\",\"some_other_property\":null}";
+
+            Assert.AreEqual(expected, json);
+        }
+
+        private class TestData
+        {
+            public string SomeProperty { get; set; }
+
+            public string SomeOtherProperty { get; set; }
         }
     }
 }

--- a/src/RestSharp.SnakeCaseSerializer.Tests/SnakeCaseSerializationStrategyTests.cs
+++ b/src/RestSharp.SnakeCaseSerializer.Tests/SnakeCaseSerializationStrategyTests.cs
@@ -7,19 +7,19 @@ namespace RestSharp.SnakeCaseSerializer.Tests
     [TestFixture]
     public class SnakeCaseSerializationStrategyTests
     {
-        private SnakeCaseSerializationStrategy strategyUnderTest;
+        private SnakeCaseSerializationStrategy _strategyUnderTest;
 
         [SetUp]
         public void SetUp()
         {
-            this.strategyUnderTest = new SnakeCaseSerializationStrategy();
-            SimpleJson.CurrentJsonSerializerStrategy = this.strategyUnderTest;
+            this._strategyUnderTest = new SnakeCaseSerializationStrategy();
+            SimpleJson.CurrentJsonSerializerStrategy = this._strategyUnderTest;
         }
 
         [TearDown]
         public void TearDown()
         {
-            this.strategyUnderTest = null;
+            this._strategyUnderTest = null;
             SimpleJson.CurrentJsonSerializerStrategy = null;
         }
 
@@ -53,7 +53,7 @@ namespace RestSharp.SnakeCaseSerializer.Tests
         [Test]
         public void WhenIgnoringNullValues_Should_Not_Serialize_Null_Properties()
         {
-            this.strategyUnderTest.IgnoreNullProperties = true;
+            this._strategyUnderTest.IgnoreNullProperties = true;
 
             var json = SimpleJson.SerializeObject(new TestData
             {
@@ -68,7 +68,7 @@ namespace RestSharp.SnakeCaseSerializer.Tests
         [Test]
         public void WhenNotIgnoringNullValues_Should_Serialize_Null_Properties()
         {
-            this.strategyUnderTest.IgnoreNullProperties = false;
+            this._strategyUnderTest.IgnoreNullProperties = false;
 
             var json = SimpleJson.SerializeObject(new TestData
             {

--- a/src/RestSharp.SnakeCaseSerializer/SnakeCaseSerializationStrategy.cs
+++ b/src/RestSharp.SnakeCaseSerializer/SnakeCaseSerializationStrategy.cs
@@ -1,9 +1,13 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace RestSharp.SnakeCaseSerializer
 {
     public class SnakeCaseSerializationStrategy : PocoJsonSerializerStrategy
     {
+        public bool IgnoreNullProperties { get; set; }
+
         protected override string MapClrMemberNameToJsonFieldName(string clrPropertyName)
         {
             var sb = new StringBuilder();
@@ -20,6 +24,18 @@ namespace RestSharp.SnakeCaseSerializer
             }
             
             return sb.ToString();
+        }
+
+        protected override bool TrySerializeUnknownTypes(object input, out object output)
+        {
+            bool returnValue =  base.TrySerializeUnknownTypes(input, out output);
+
+            if (this.IgnoreNullProperties && output is IDictionary<string, object> obj)
+            {
+                output = obj.Where(o => o.Value != null).ToDictionary(o => o.Key, o => o.Value);
+            }
+
+            return returnValue;
         }
 
         private static bool ShouldPrefixUnderscore(char c, char pc)

--- a/src/RestSharp.SnakeCaseSerializer/SnakeCaseSerializationStrategy.cs
+++ b/src/RestSharp.SnakeCaseSerializer/SnakeCaseSerializationStrategy.cs
@@ -30,8 +30,9 @@ namespace RestSharp.SnakeCaseSerializer
         {
             bool returnValue =  base.TrySerializeUnknownTypes(input, out output);
 
-            if (this.IgnoreNullProperties && output is IDictionary<string, object> obj)
+            if (this.IgnoreNullProperties && output is IDictionary<string, object>)
             {
+                IDictionary<string, object> obj = output as IDictionary<string, object>;
                 output = obj.Where(o => o.Value != null).ToDictionary(o => o.Key, o => o.Value);
             }
 


### PR DESCRIPTION
Added a property `IgnoreNullProperties` that when true prevents null properties from being serialized.